### PR TITLE
fix: hides volunteers and donations sections when no data available

### DIFF
--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -60,30 +60,34 @@ export function Card({ shelter }: Props) {
         </Link>
       </CardHeader>
       <CardContent className="space-y-4">
-        <CardSection title="Doações necessárias">
-          <BadgeList>
-            {shelter.donations.map((need) => (
-              <Badge
-                key={need}
-                className="rounded-sm bg-[rgba(240,240,240,1)] font-normal text-slate-500"
-              >
-                {need}
-              </Badge>
-            ))}
-          </BadgeList>
-        </CardSection>
-        <CardSection title="Voluntários necessários">
-          <BadgeList>
-            {shelter.volunteers.map((volunteer) => (
-              <Badge
-                key={volunteer}
-                className="rounded-sm bg-[rgba(240,240,240,1)] font-normal text-slate-500"
-              >
-                {volunteer}
-              </Badge>
-            ))}
-          </BadgeList>
-        </CardSection>
+        {shelter?.donations.length > 0 && (
+          <CardSection title="Doações necessárias">
+            <BadgeList>
+              {shelter.donations.map((need) => (
+                <Badge
+                  key={need}
+                  className="rounded-sm bg-[rgba(240,240,240,1)] font-normal text-slate-500"
+                >
+                  {need}
+                </Badge>
+              ))}
+            </BadgeList>
+          </CardSection>
+        )}
+        {shelter?.volunteers.length > 0 && (
+          <CardSection title="Voluntários necessários">
+            <BadgeList>
+              {shelter.volunteers.map((volunteer) => (
+                <Badge
+                  key={volunteer}
+                  className="rounded-sm bg-[rgba(240,240,240,1)] font-normal text-slate-500"
+                >
+                  {volunteer}
+                </Badge>
+              ))}
+            </BadgeList>
+          </CardSection>
+        )}
       </CardContent>
       <CardFooter className="flex items-center justify-between gap-4">
         <a


### PR DESCRIPTION
- Updates logic to display volunteers and donations sections only when there is data available to be displayed

### Previously
![image](https://github.com/emiliosheinz/sos-pet/assets/85116841/fe09a12c-1408-483f-8ad3-d2c365683151)


### Now 
![image](https://github.com/emiliosheinz/sos-pet/assets/85116841/d6aada8f-fcc2-43db-ad3d-1d855e3920e2)
