### PR TITLE
fix: ci pull request target

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,14 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/sos-pet"
 
 # Next Auth
 NEXTAUTH_URL="http://localhost:3000"
-NEXTAUTH_SECRET="nextauthsecret"
+NEXTAUTH_SECRET="nextauth-secret"
 
 # Next Auth Providers
-GOOGLE_CLIENT_ID=""
-GOOGLE_CLIENT_SECRET=""
+GOOGLE_CLIENT_ID="google-client-id"
+GOOGLE_CLIENT_SECRET="google-client-secret"
 
 # Google Maps
-NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=""
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY="google-maps-api-key"
 
 # Docker related variables, not used on Next.js
 POSTGRES_DB="sos-pet"

--- a/.github/workflows/lint-type-check-and-build.yaml
+++ b/.github/workflows/lint-type-check-and-build.yaml
@@ -1,7 +1,7 @@
 name: 🚀 Lint, Type Check, and Build
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - dev
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -23,7 +21,7 @@ jobs:
           cache: "yarn"
 
       - name: Setup .env file
-        run: echo "${{ secrets.DOT_ENV_FILE_CONTENT }}" > .env
+        run: cat .env.example > .env
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/lint-type-check-and-build.yaml
+++ b/.github/workflows/lint-type-check-and-build.yaml
@@ -21,6 +21,9 @@ jobs:
           cache: "yarn"
 
       - name: Setup .env file
+        # All the environment variables in .env.example are invalid,
+        # therefore the application will not be functional. But, it is enough
+        # for linting, type checking, and building.
         run: cat .env.example > .env
 
       - name: Install dependencies

--- a/.github/workflows/lint-type-check-and-build.yaml
+++ b/.github/workflows/lint-type-check-and-build.yaml
@@ -1,7 +1,7 @@
 name: 🚀 Lint, Type Check, and Build
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - dev
@@ -9,9 +9,12 @@ on:
 jobs:
   lint-type-check-and-build:
     runs-on: ubuntu-latest
+    name: Lint, Type Check, and Build
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Como descrito [nessa issue](https://github.com/orgs/community/discussions/50161) pull requests abertos a partir de forks não tem acesso a secretes. Por esse motivo, os checks [neste PR](https://github.com/emiliosheinz/sos-pet/pull/54) estavam falhando. Dessa forma, como a aplicação não precisa estar funcional para que rodemos o Lint, Type Check e Build, decidi simplesmente copiar o conteúdo do arquivo `.env.example` para dentro do arquivo `.env` durante o pipeline. Assim, deixando de acessar as secrets. 

Isso fará com que o processo seja mais simples, e continue executando as validações necessárias. 